### PR TITLE
Add joystick support for RPI

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -60,6 +60,17 @@ def configure(env):
 		env.ParseConfig('pkg-config libpng --cflags --libs')
 	if (env['builtin_zlib'] == 'no'):
 		env.ParseConfig('pkg-config zlib --cflags --libs')
+        # pkg-config returns 0 when the lib exists...
+        found_udev = not os.system("pkg-config --exists libudev")
+
+        if (found_udev):
+            print("Enabling udev support")
+            env.Append(CPPFLAGS=["-DUDEV_ENABLED"])
+            env.ParseConfig('pkg-config libudev --cflags --libs')
+            env.Append(CPPFLAGS=["-DJOYDEV_ENABLED"])
+            env.Append(FRT_MODULES=['../x11/joystick_linux.cpp'])
+        else:
+            print("libudev development libraries not found, disabling udev support")
 
 	if version.major == 2:
 		if version.minor == 1 and version.patch >=4:
@@ -92,7 +103,7 @@ def configure(env):
 	if (env["frt_arch"].startswith("pi")):
 		env.Append(CCFLAGS=['-mfloat-abi=hard', '-mlittle-endian', '-munaligned-access'])
 
-	env.Append(CPPFLAGS=['-DUNIX_ENABLED', '-DGLES2_ENABLED'])
+	env.Append(CPPFLAGS=['-DFRT_ENABLED', '-DUNIX_ENABLED', '-DGLES2_ENABLED'])
 	env.Append(LIBS=['pthread'])
 
 	if (env["frt_arch"] == "pc"):

--- a/joystick_linux.h
+++ b/joystick_linux.h
@@ -1,0 +1,101 @@
+/*************************************************************************/
+/*  joystick_linux.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+//author: Andreas Haas <hondres,  liugam3@gmail.com>
+#ifndef JOYSTICK_LINUX_H
+#define JOYSTICK_LINUX_H
+#ifdef JOYDEV_ENABLED
+#include "main/input_default.h"
+#include "os/mutex.h"
+#include "os/thread.h"
+
+struct input_absinfo;
+
+class joystick_linux {
+public:
+	joystick_linux(InputDefault *in);
+	~joystick_linux();
+	uint32_t process_joysticks(uint32_t p_event_id);
+
+private:
+	enum {
+		JOYSTICKS_MAX = 16,
+		MAX_ABS = 63,
+		MAX_KEY = 767, // Hack because <linux/input.h> can't be included here
+	};
+
+	struct Joystick {
+		InputDefault::JoyAxis curr_axis[MAX_ABS];
+		int key_map[MAX_KEY];
+		int abs_map[MAX_ABS];
+		int dpad;
+		int fd;
+
+		String devpath;
+		input_absinfo *abs_info[MAX_ABS];
+
+		bool force_feedback;
+		int ff_effect_id;
+		uint64_t ff_effect_timestamp;
+
+		Joystick();
+		~Joystick();
+		void reset();
+	};
+
+	bool exit_udev;
+	Mutex *joy_mutex;
+	Thread *joy_thread;
+	InputDefault *input;
+	Joystick joysticks[JOYSTICKS_MAX];
+	Vector<String> attached_devices;
+
+	static void joy_thread_func(void *p_user);
+
+	int get_joy_from_path(String path) const;
+
+	void setup_joystick_properties(int p_id);
+	void close_joystick(int p_id = -1);
+#ifdef UDEV_ENABLED
+	void enumerate_joysticks(struct udev *_udev);
+	void monitor_joysticks(struct udev *_udev);
+#endif
+	void monitor_joysticks();
+	void run_joystick_thread();
+	void open_joystick(const char *path);
+
+	void joystick_vibration_start(int p_id, float p_weak_magnitude, float p_strong_magnitude, float p_duration, uint64_t p_timestamp);
+	void joystick_vibration_stop(int p_id, uint64_t p_timestamp);
+
+	InputDefault::JoyAxis axis_correct(const input_absinfo *abs, int value) const;
+};
+
+#endif
+#endif // JOYSTICK_LINUX_H


### PR DESCRIPTION
Copied  `joystick_linux.h` from `platform/x11`.
Build script now includes external platform file `platform/x11/joystick_linux.cpp`.
Add `FRT_ENABLED` compiler define.
Needs the following patch to `main/input_default.cpp` to get normalized axis/button mapping.
```
diff --git a/main/input_default.cpp b/main/input_default.cpp
index 5e923af9f..4799def2e 100644
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -620,7 +620,7 @@ static const char *s_ControllerMappings[] = {
        "d814000000000000cecf000000000000,MC Cthulhu,leftx:,lefty:,rightx:,righty:,lefttrigger:b6,a:b1,b:b2,y:b3,x:b0,start:b9,back:b8,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,righttrigger:b7,",
 #endif
 
-#if X11_ENABLED
+#if X11_ENABLED || FRT_ENABLED
        "0000000058626f782047616d65706100,Xbox Gamepad (userspace driver),a:b0,b:b1,x:b2,y:b3,start:b7,back:b6,guide:b8,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftshoulder:b4,rightshoulder:b5,lefttrigger:a5,righttrigger:a4,leftstick:b9,rightstick:b10,leftx:a0,lefty:a1,rightx:a2,righty:a3,",
        "0300000000f000000300000000010000,RetroUSB.com RetroPad,a:b1,b:b5,x:b0,y:b4,back:b2,start:b3,leftshoulder:b6,rightshoulder:b7,leftx:a0,lefty:a1,",
        "0300000000f00000f100000000010000,RetroUSB.com Super RetroPort,a:b1,b:b5,x:b0,y:b4,back:b2,start:b3,leftshoulder:b6,rightshoulder:b7,leftx:a0,lefty:a1,",
```
There is probably another way to do the mapping using `Input::add_joy_mapping` and without patching the source and just copying the values but I don't have time to investigate for now.